### PR TITLE
ISSUE-4 Fix timezone warning upon submit success

### DIFF
--- a/inc/functions/functions.inc.php
+++ b/inc/functions/functions.inc.php
@@ -229,10 +229,12 @@ function checkFile($filename) {
 }
 
 function getDateTimeISO($timestamp) {
+	date_default_timezone_set('UTC');
 	return date("Y-m-d\TH:i:s", $timestamp) . substr(date("O"),0,3) . ":" . substr(date("O"),3);
 }
 
 function getDateTimeISO_short($timestamp) {
+	date_default_timezone_set('UTC');
 	return date("Y-m-d", $timestamp);
 }
 


### PR DESCRIPTION
Hi @eniad this issue removes the warning from the page when it renders, however I don't know if it is the right mechanism for implementing the timezone. I am not even on UTC, however this is what it was being set to anyways... ideally we would obtain the local timezone from the machine the code is being executed on...
This issue is associated with #4 